### PR TITLE
Deploy wheel and web app on GitHub pages

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,66 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger this workflow when the 'Build Python Wheel' workflow completes successfully
+  workflow_run:
+    workflows: ["Build Python Wheel"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read # Required to download artifacts from workflow_run
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # Only run if the triggering workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheel # Must match the upload name in build_wheel.yml
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./temp-wheel-artifact # Download to a temporary directory
+
+      - name: Prepare deployment artifact structure
+        run: |
+          mkdir -p _site/dist
+          echo "Moving wheel(s)..."
+          mv ./temp-wheel-artifact/* _site/dist/
+          echo "Checking for webapp directory..."
+          if [ -d "webapp" ]; then
+            echo "Copying webapp contents..."
+            # Use rsync for potentially better handling of files/directories
+            rsync -av --exclude='.git*' webapp/ _site/
+          else
+            echo "webapp directory not found, skipping copy."
+          fi
+          echo "Final structure in _site:"
+          ls -R _site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site' # Upload the prepared directory
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        # No 'with' section needed, deployment action reads from the uploaded artifact

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,1 @@
+Placeholder for web app for easily testing out the parser.


### PR DESCRIPTION
There will be a pyodide based web app for quickly testing the parser in `/webapp/`. In this branch, a workflow publishes that web app. This will need to be rebased once the web app is in place.